### PR TITLE
Custom Server File Location

### DIFF
--- a/API.md
+++ b/API.md
@@ -92,13 +92,13 @@ server.lambda({
 ```
 
 ## The Serverless plugin
-Lalalambda takes no options when used as a Serverless plugin.  Currently the plugin only supports the [`aws` Serverless provider](https://serverless.com/framework/docs/providers/aws/), and each function deployed via lalalambda must use the `nodejs8.10` runtime or newer (`nodejs12.x` is recommended).  The plugin is responsible for:
+Currently the plugin only supports the [`aws` Serverless provider](https://serverless.com/framework/docs/providers/aws/), and each function deployed via lalalambda must use the `nodejs8.10` runtime or newer (`nodejs12.x` is recommended).  The plugin is responsible for:
 
 1. Configuring the project's Serverless service based upon relevant lambda and route configurations made within hapi.
 
 2. Writing lambda handler files during packaging, deployment, local invocation, etc., and later cleaning them up.  These files will be written in your project root's `_lalalambda/` directory.
 
-In order to interoperate with your hapi server, it is expected that `server.js` or `server/index.js` export an async function named `deployment` returning your configured hapi server.  This server should have the [lalalambda hapi plugin](#the-hapi-plugin) registered.
+In order to interoperate with your hapi server, it is expected that `server.js` or `server/index.js` export an async function named `deployment` returning your configured hapi server.  This server should have the [lalalambda hapi plugin](#the-hapi-plugin) registered.  The path to `server.js` can also be customized through the `custom.lalalambda` config section as shown below.
 
 A minimal Serverless [config](https://serverless.com/framework/docs/providers/aws/guide/serverless.yml/) utilizing lalalambda will look like this:
 
@@ -109,6 +109,11 @@ service: my-service
 provider:
   name: aws
   runtime: nodejs12.x
+
+# optional
+custom:
+  lalalambda:
+    serverPath: some/relative/path/to/server.js
 
 plugins:
   - lalalambda

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ Lalalambda is one package that doubles as 1. a hapi plugin and 2. a [Serverless 
      - lalalambda
    ```
 
+    There is also an optional configuration for declaring the path to the server file.
+
+   ```yaml
+   # serverless.yml
+
+   custom:
+     lalalambda:
+       serverPath: 'src/my-server.js'  # This is always relative to the serverless.yml file.
+   ```
+
 3. Register lalalambda to your hapi server.
 
    > If you're using [the pal boilerplate](https://github.com/hapipal/boilerplate) then simply add lalalambda to your [manifest's](https://github.com/hapipal/boilerplate/blob/pal/server/manifest.js) `plugins` section.

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -54,7 +54,7 @@ exports.Plugin = class {
 
         const { servicePath } = this.sls.config;
 
-        const rootOrPath = Path.join(servicePath, Hoek.reach(this.sls, 'service.custom.lalalambda.serverPath') || '');
+        const rootOrPath = Path.resolve(servicePath, Hoek.reach(this.sls, 'service.custom.lalalambda.serverPath') || '');
 
         const server = this.server = await internals.getServer(rootOrPath);
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -7,6 +7,8 @@ const Hoek = require('@hapi/hoek');
 const Somever = require('@hapi/somever');
 const Rimraf = require('rimraf');
 
+const stat = Util.promisify(Fs.stat);
+
 const internals = {};
 const BUILD_FOLDER = '_lalalambda';
 
@@ -51,7 +53,9 @@ exports.Plugin = class {
 
         const { servicePath } = this.sls.config;
 
-        const server = this.server = await internals.getServer(servicePath);
+        const rootOrPath = Path.join(servicePath, Hoek.reach(this.sls, 'service.custom.lalalambda.serverPath') || '');
+
+        const server = this.server = await internals.getServer(rootOrPath);
 
         Hoek.assert(server.plugins.lalalambda, 'Lalalambda needs to be registered as a plugin on your hapi server.');
     }
@@ -151,15 +155,21 @@ internals.writeFile = Util.promisify(Fs.writeFile);
 
 internals.rimraf = Util.promisify(Rimraf);
 
-internals.getServer = async (root) => {
+internals.getServer = async (rootOrPath) => {
 
-    const path = Path.join(root, 'server');
+    let path = Path.join(rootOrPath, 'server');
+
+    try {
+        await stat(rootOrPath.endsWith('js') ? rootOrPath : `${rootOrPath}.js`);
+        path = rootOrPath;
+    }
+    catch (err) { }
 
     try {
 
         const srv = require(path);
 
-        Hoek.assert(typeof srv.deployment === 'function', `No server found! The current project must export { deployment: async () => server } from ${root}/server.`);
+        Hoek.assert(typeof srv.deployment === 'function', `No server found! The current project must export { deployment: async () => server } from ${path}.`);
 
         const server = await srv.deployment();
 
@@ -169,7 +179,7 @@ internals.getServer = async (root) => {
     }
     catch (err) {
 
-        Hoek.assert(err.code !== 'MODULE_NOT_FOUND' || !err.message.includes(`'${path}'`), `No server found! The current project must export { deployment: async () => server } from ${root}/server.`);
+        Hoek.assert(err.code !== 'MODULE_NOT_FOUND' || !err.message.includes(`'${path}'`), `No server found! The current project must export { deployment: async () => server } from ${path}.`);
 
         throw err;
     }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -111,7 +111,7 @@ exports.Plugin = class {
         for (const id of lambdas.keys()) {
             await internals.writeFile(
                 Path.join(servicePath, BUILD_FOLDER, `${id}.js`),
-                internals.entrypoint(id)
+                internals.entrypoint(id, Hoek.reach(this.sls, 'service.custom.lalalambda.serverPath'))
             );
         }
     }
@@ -186,10 +186,10 @@ internals.getServer = async (rootOrPath) => {
 };
 
 // eslint-disable-next-line @hapi/hapi/scope-start
-internals.entrypoint = (id) => `'use strict';
+internals.entrypoint = (id, serverPath = '') => `'use strict';
 
 const Path = require('path');
 const Lalalambda = require('lalalambda');
 
-exports.handler = Lalalambda.handler('${id}', Path.resolve(__dirname, '..'));
+exports.handler = Lalalambda.handler('${id}', Path.resolve(__dirname, '..', '${serverPath}'));
 `;

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -3,6 +3,7 @@
 const Path = require('path');
 const Util = require('util');
 const Fs = require('fs');
+const Bounce = require('@hapi/bounce');
 const Hoek = require('@hapi/hoek');
 const Somever = require('@hapi/somever');
 const Rimraf = require('rimraf');
@@ -160,10 +161,11 @@ internals.getServer = async (rootOrPath) => {
     let path = Path.join(rootOrPath, 'server');
 
     try {
-        await stat(rootOrPath.endsWith('js') ? rootOrPath : `${rootOrPath}.js`);
-        path = rootOrPath;
+        path = require.resolve(rootOrPath);
     }
-    catch (err) { }
+    catch (err) { 
+        Bounce.rethrow(err, 'system');
+    }
 
     try {
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -3,7 +3,6 @@
 const Path = require('path');
 const Util = require('util');
 const Fs = require('fs');
-const Bounce = require('@hapi/bounce');
 const Hoek = require('@hapi/hoek');
 const Somever = require('@hapi/somever');
 const Rimraf = require('rimraf');
@@ -50,11 +49,7 @@ exports.Plugin = class {
 
     async initialize() {
 
-        const { servicePath } = this.sls.config;
-
-        const rootOrPath = Path.resolve(servicePath, Hoek.reach(this.sls, 'service.custom.lalalambda.serverPath') || '');
-
-        const server = this.server = await internals.getServer(rootOrPath);
+        const server = this.server = await internals.getServer(this.serverPath);
 
         Hoek.assert(server.plugins.lalalambda, 'Lalalambda needs to be registered as a plugin on your hapi server.');
     }
@@ -103,17 +98,34 @@ exports.Plugin = class {
         Hoek.assert(server, 'Lalalambda must be initialized.');
 
         const { servicePath } = this.sls.config;
-        const { lambdas } = server.plugins.lalalambda;
+        const buildFolderPath = Path.join(servicePath, BUILD_FOLDER);
 
         await this.cleanup();
-        await internals.mkdir(Path.join(servicePath, BUILD_FOLDER));
+        await internals.mkdir(buildFolderPath);
+
+        const { lambdas } = server.plugins.lalalambda;
 
         for (const id of lambdas.keys()) {
             await internals.writeFile(
-                Path.join(servicePath, BUILD_FOLDER, `${id}.js`),
-                internals.entrypoint(id, Hoek.reach(this.sls, 'service.custom.lalalambda.serverPath'))
+                Path.join(buildFolderPath, `${id}.js`),
+                // Path listed in entrypoint should be relative
+                // in order for the code to remain portable.
+                internals.entrypoint(id, Path.relative(buildFolderPath, this.serverPath))
             );
         }
+    }
+
+    get serverPath() {
+
+        const { servicePath } = this.sls.config;
+
+        const serverPath = Hoek.reach(
+            this.sls,
+            ['service', 'custom', 'lalalambda', 'serverPath'],
+            { default: 'server' }
+        );
+
+        return Path.resolve(servicePath, serverPath);
     }
 };
 
@@ -154,16 +166,7 @@ internals.writeFile = Util.promisify(Fs.writeFile);
 
 internals.rimraf = Util.promisify(Rimraf);
 
-internals.getServer = async (rootOrPath) => {
-
-    let path = Path.join(rootOrPath, 'server');
-
-    try {
-        path = require.resolve(rootOrPath);
-    }
-    catch (err) {
-        Bounce.rethrow(err, 'system');
-    }
+internals.getServer = async (path) => {
 
     try {
 
@@ -186,10 +189,13 @@ internals.getServer = async (rootOrPath) => {
 };
 
 // eslint-disable-next-line @hapi/hapi/scope-start
-internals.entrypoint = (id, serverPath = '') => `'use strict';
+internals.entrypoint = (id, path) => `'use strict';
 
 const Path = require('path');
 const Lalalambda = require('lalalambda');
 
-exports.handler = Lalalambda.handler('${id}', Path.resolve(__dirname, '..', '${serverPath}'));
+exports.handler = Lalalambda.handler('${internals.esc(id)}', Path.resolve(__dirname, '${internals.esc(path)}'));
 `;
+
+// Allow slashes and single-quotes in filenames
+internals.esc = (str) => str.replace(/(\\|')/g, '\\$1');

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -8,8 +8,6 @@ const Hoek = require('@hapi/hoek');
 const Somever = require('@hapi/somever');
 const Rimraf = require('rimraf');
 
-const stat = Util.promisify(Fs.stat);
-
 const internals = {};
 const BUILD_FOLDER = '_lalalambda';
 
@@ -163,7 +161,7 @@ internals.getServer = async (rootOrPath) => {
     try {
         path = require.resolve(rootOrPath);
     }
-    catch (err) { 
+    catch (err) {
         Bounce.rethrow(err, 'system');
     }
 

--- a/test/closet/invoke-custom-server-path-escaped/'.js
+++ b/test/closet/invoke-custom-server-path-escaped/'.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { Hapi } = require('../../helpers');
+const Lalalambda = require('../../..');
+
+exports.deployment = async () => {
+
+    const server = Hapi.server();
+
+    await server.register(Lalalambda);
+
+    server.lambda({
+        id: 'invoke-lambda',
+        handler: () => ({ success: 'invoked' })
+    });
+
+    return server;
+};

--- a/test/closet/invoke-custom-server-path-escaped/.serverless_plugins/lalalambda.js
+++ b/test/closet/invoke-custom-server-path-escaped/.serverless_plugins/lalalambda.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../../..');

--- a/test/closet/invoke-custom-server-path-escaped/serverless.yaml
+++ b/test/closet/invoke-custom-server-path-escaped/serverless.yaml
@@ -1,0 +1,12 @@
+service: my-service
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+custom:
+  lalalambda:
+    serverPath: "'.js"
+
+plugins:
+  - lalalambda

--- a/test/closet/invoke-custom-server-path/.serverless_plugins/lalalambda.js
+++ b/test/closet/invoke-custom-server-path/.serverless_plugins/lalalambda.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../../..');

--- a/test/closet/invoke-custom-server-path/serverless.yaml
+++ b/test/closet/invoke-custom-server-path/serverless.yaml
@@ -1,0 +1,12 @@
+service: my-service
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+custom:
+  lalalambda:
+    serverPath: 'src/server.js'
+
+plugins:
+  - lalalambda

--- a/test/closet/invoke-custom-server-path/src/server.js
+++ b/test/closet/invoke-custom-server-path/src/server.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { Hapi } = require('../../../helpers');
+const Lalalambda = require('../../../..');
+
+exports.deployment = async () => {
+
+    const server = Hapi.server();
+
+    await server.register(Lalalambda);
+
+    server.lambda({
+        id: 'invoke-lambda',
+        handler: () => ({ success: 'invoked' })
+    });
+
+    return server;
+};

--- a/test/closet/invoke/index.js
+++ b/test/closet/invoke/index.js
@@ -1,0 +1,2 @@
+// This exists to ensure that when serverPath isn't specified, this file
+// doesn't get picked-up as the default server export rather than server.js

--- a/test/closet/missing-server-file/.serverless_plugins/lalalambda.js
+++ b/test/closet/missing-server-file/.serverless_plugins/lalalambda.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../../..');

--- a/test/closet/missing-server-file/.serverless_plugins/serverless-offline-mock.js
+++ b/test/closet/missing-server-file/.serverless_plugins/serverless-offline-mock.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Helpers = require('../../../helpers');
+
+module.exports = Helpers.OfflineMock;

--- a/test/closet/missing-server-file/serverless.yaml
+++ b/test/closet/missing-server-file/serverless.yaml
@@ -1,0 +1,9 @@
+service: my-service
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+plugins:
+  - lalalambda
+  - serverless-offline-mock

--- a/test/closet/server-file-location-with-file-extension/.serverless_plugins/lalalambda.js
+++ b/test/closet/server-file-location-with-file-extension/.serverless_plugins/lalalambda.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../../..');

--- a/test/closet/server-file-location-with-file-extension/.serverless_plugins/serverless-offline-mock.js
+++ b/test/closet/server-file-location-with-file-extension/.serverless_plugins/serverless-offline-mock.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Helpers = require('../../../helpers');
+
+module.exports = Helpers.OfflineMock;

--- a/test/closet/server-file-location-with-file-extension/serverless.yaml
+++ b/test/closet/server-file-location-with-file-extension/serverless.yaml
@@ -1,0 +1,13 @@
+service: my-service
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+custom:
+  lalalambda:
+    serverPath: 'src/server.js'
+
+plugins:
+  - lalalambda
+  - serverless-offline-mock

--- a/test/closet/server-file-location-with-file-extension/src/server.js
+++ b/test/closet/server-file-location-with-file-extension/src/server.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { Hapi } = require('../../../helpers');
+const Lalalambda = require('../../../../lib');
+
+exports.deployment = async () => {
+
+    const server = Hapi.server();
+
+    await server.register(Lalalambda);
+
+    return server;
+};

--- a/test/closet/server-file-location-without-file-extension/.serverless_plugins/lalalambda.js
+++ b/test/closet/server-file-location-without-file-extension/.serverless_plugins/lalalambda.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../../..');

--- a/test/closet/server-file-location-without-file-extension/.serverless_plugins/serverless-offline-mock.js
+++ b/test/closet/server-file-location-without-file-extension/.serverless_plugins/serverless-offline-mock.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Helpers = require('../../../helpers');
+
+module.exports = Helpers.OfflineMock;

--- a/test/closet/server-file-location-without-file-extension/serverless.yaml
+++ b/test/closet/server-file-location-without-file-extension/serverless.yaml
@@ -1,0 +1,13 @@
+service: my-service
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+custom:
+  lalalambda:
+    serverPath: 'src/server'
+
+plugins:
+  - lalalambda
+  - serverless-offline-mock

--- a/test/closet/server-file-location-without-file-extension/src/server.js
+++ b/test/closet/server-file-location-without-file-extension/src/server.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { Hapi } = require('../../../helpers');
+const Lalalambda = require('../../../../lib');
+
+exports.deployment = async () => {
+
+    const server = Hapi.server();
+
+    await server.register(Lalalambda);
+
+    return server;
+};

--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,7 @@ const Rimraf = require('rimraf');
 const StreamZip = require('node-stream-zip');
 const { Hapi, ...Helpers } = require('./helpers');
 const Lalalambda = require('..');
-const { server } = require('@hapi/hapi');
+// const { server } = require('@hapi/hapi');
 
 // Test shortcuts
 

--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,6 @@ const Rimraf = require('rimraf');
 const StreamZip = require('node-stream-zip');
 const { Hapi, ...Helpers } = require('./helpers');
 const Lalalambda = require('..');
-// const { server } = require('@hapi/hapi');
 
 // Test shortcuts
 

--- a/test/index.js
+++ b/test/index.js
@@ -1313,6 +1313,17 @@ describe('Lalalambda', () => {
             expect(output).to.contain(`"success": "invoked"`);
         });
 
+        it('can locally invoke a lambda registered by hapi to a custom serverpath.', async () => {
+
+            const serverless = Helpers.makeServerless('invoke-custom-server-path', ['invoke', 'local', '--function', 'invoke-lambda']);
+
+            await serverless.init();
+
+            const output = await serverless.run();
+
+            expect(output).to.contain(`"success": "invoked"`);
+        });
+
         it('invokes lambdas registered by hapi with server and bound context.', async () => {
 
             const serverless = Helpers.makeServerless('invoke-context', ['invoke', 'local', '--function', 'invoke-context-lambda', '--data', '{"an":"occurrence"}']);
@@ -1423,7 +1434,7 @@ describe('Lalalambda', () => {
                 const Path = require('path');
                 const Lalalambda = require('lalalambda');
 
-                exports.handler = Lalalambda.handler('package-lambda', Path.resolve(__dirname, '..'));
+                exports.handler = Lalalambda.handler('package-lambda', Path.resolve(__dirname, '..', ''));
             `));
 
             const cfFile = await readFile(Path.join(__dirname, 'closet', 'package', '.serverless', 'cloudformation-template-update-stack.json'));

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,7 @@ const Rimraf = require('rimraf');
 const StreamZip = require('node-stream-zip');
 const { Hapi, ...Helpers } = require('./helpers');
 const Lalalambda = require('..');
+const { server } = require('@hapi/hapi');
 
 // Test shortcuts
 
@@ -1255,6 +1256,24 @@ describe('Lalalambda', () => {
             await serverless.init();
 
             await expect(serverless.run()).to.reject(`No server found! The current project must export { deployment: async () => server } from ${Path.join(__dirname, '/closet/missing-server-file/server.')}`);
+        });
+
+        it('can load the server file with file extension from a custom path', async () => {
+
+            const serverless = Helpers.makeServerless('server-file-location-with-file-extension', []);
+
+            await serverless.init();
+
+            await expect(serverless.run()).to.not.reject();
+        });
+
+        it('can load the server file without file extension from a custom path', async () => {
+
+            const serverless = Helpers.makeServerless('server-file-location-without-file-extension', []);
+
+            await serverless.init();
+
+            await expect(serverless.run()).to.not.reject();
         });
 
         it('fails when deployment does not exist.', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -1313,9 +1313,20 @@ describe('Lalalambda', () => {
             expect(output).to.contain(`"success": "invoked"`);
         });
 
-        it('can locally invoke a lambda registered by hapi to a custom serverpath.', async () => {
+        it('can locally invoke a lambda registered by hapi to a custom serverPath.', async () => {
 
             const serverless = Helpers.makeServerless('invoke-custom-server-path', ['invoke', 'local', '--function', 'invoke-lambda']);
+
+            await serverless.init();
+
+            const output = await serverless.run();
+
+            expect(output).to.contain(`"success": "invoked"`);
+        });
+
+        it('can locally invoke a lambda registered by hapi to a custom serverPath containing a single quote.', async () => {
+
+            const serverless = Helpers.makeServerless('invoke-custom-server-path-escaped', ['invoke', 'local', '--function', 'invoke-lambda']);
 
             await serverless.init();
 
@@ -1434,7 +1445,7 @@ describe('Lalalambda', () => {
                 const Path = require('path');
                 const Lalalambda = require('lalalambda');
 
-                exports.handler = Lalalambda.handler('package-lambda', Path.resolve(__dirname, '..', ''));
+                exports.handler = Lalalambda.handler('package-lambda', Path.resolve(__dirname, '../server'));
             `));
 
             const cfFile = await readFile(Path.join(__dirname, 'closet', 'package', '.serverless', 'cloudformation-template-update-stack.json'));

--- a/test/index.js
+++ b/test/index.js
@@ -1248,6 +1248,15 @@ describe('Lalalambda', () => {
             });
         });
 
+        it('fails when server file does not exist', async () => {
+
+            const serverless = Helpers.makeServerless('missing-server-file', []);
+
+            await serverless.init();
+
+            await expect(serverless.run()).to.reject(`No server found! The current project must export { deployment: async () => server } from ${Path.join(__dirname, '/closet/missing-server-file/server.')}`);
+        });
+
         it('fails when deployment does not exist.', async () => {
 
             const serverless = Helpers.makeServerless('bad-deployment-missing', []);


### PR DESCRIPTION
## Description

Added the ability to specify where the entry file that returns the Hapi `server` object is located.  In the `serverless.yml`, You can specify it with a path relative to where the `serverless.yml` is located.  

## Examples

```yaml
# serverless.yml
service: my-service

provider:
  name: aws
  runtime: nodejs12.x

custom:
  # optional
  lalalambda:
    serverPath: 'src/server.js'

plugins:
  - lalalambda
  - serverless-offline-mock

```

or 

```yaml
# serverless.yml
service: my-service

provider:
  name: aws
  runtime: nodejs12.x

custom:
  # optional
  lalalambda:
    serverPath: 'src/server'

plugins:
  - lalalambda
  - serverless-offline-mock

```

## Testing

* When no file is found even for the default `hapipal` template case of `<root>/server`
* When file is specified to a non default location with the `js` file extension with no lambda defined.
* When file is specified to a non default location no file extension specified with no lambda defined.
* When file is specified to a non default location with a lambda defined and invoked.

## Documentation

* Added small example and note to the preexisting `serverless.yml` declaration.
* Added and subtracted documentation around the Serverless section