### PR TITLE
feat: drop support node < 12 & hapi < 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: node_js
 
+env:
+  - HAPI_VERSION="19"
+  - HAPI_VERSION="20"
+
 node_js:
-  - "8"
-  - "10"
   - "12"
   - "14"
   - "node"
+
+install:
+  - "npm install"
+  - "npm install @hapi/hapi@$HAPI_VERSION"
 
 after_script: "npm run coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,5 @@
-language: node_js
+version: ~> 1.0
 
-env:
-  - HAPI_VERSION="19"
-  - HAPI_VERSION="20"
-
-node_js:
-  - "12"
-  - "14"
-  - "node"
-
-install:
-  - "npm install"
-  - "npm install @hapi/hapi@$HAPI_VERSION"
-
-after_script: "npm run coveralls"
-
-jobs:
-  fast_finish: true
-  allow_failures:
-    - node_js: "node"
+import:
+  - hapipal/ci-config-travis:node_js.yml@master
+  - hapipal/ci-config-travis:hapi_all.yml@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,8 @@ install:
   - "npm install @hapi/hapi@$HAPI_VERSION"
 
 after_script: "npm run coveralls"
+
+jobs:
+  fast_finish: true
+  allow_failures:
+    - node_js: "node"

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -80,7 +80,7 @@ exports.Plugin = class {
             const runtime = fnConfig.runtime || sls.service.provider.runtime;
 
             Hoek.assert(runtime && runtime.startsWith('nodejs'), `Lambda "${id}" must be configured with a nodejs runtime.`);
-            Hoek.assert(Somever.match(runtime.slice(6), '>=8.10'), `Lambda "${id}" must be configured with a nodejs runtime >=8.10.`);
+            Hoek.assert(Somever.match(runtime.slice(6), '>=12'), `Lambda "${id}" must be configured with a nodejs runtime >=12.`);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -30,25 +30,24 @@
   },
   "homepage": "https://github.com/hapipal/lalalambda#readme",
   "dependencies": {
-    "@hapi/hoek": "8.x.x",
+    "@hapi/hoek": "9.x.x",
     "@hapi/joi": "16.x.x",
-    "@hapi/somever": "2.x.x",
-    "rimraf": "2.x.x"
+    "@hapi/somever": "3.x.x",
+    "rimraf": "3.x.x"
   },
   "peerDependencies": {
-    "@hapi/hapi": ">=17 <21"
+    "@hapi/hapi": ">=19 <21"
   },
   "devDependencies": {
-    "@hapi/bounce": "1.x.x",
-    "@hapi/code": "6.x.x",
-    "@hapi/hapi": "18.x.x",
-    "@hapi/hapi-20": "npm:@hapi/hapi@20",
-    "@hapi/lab": "20.x.x",
+    "@hapi/bounce": "2.x.x",
+    "@hapi/code": "8.x.x",
+    "@hapi/hapi": "20.x.x",
+    "@hapi/lab": "23.x.x",
     "coveralls": "3.x.x",
     "node-stream-zip": "1.x.x",
     "serverless": "1.x.x",
     "serverless-offline": "5.x.x",
-    "strip-ansi": "5.x.x",
+    "strip-ansi": "6.x.x",
     "toys": "2.x.x"
   }
 }

--- a/test/closet/config-merge/server.js
+++ b/test/closet/config-merge/server.js
@@ -28,7 +28,7 @@ exports.deployment = async () => {
     server.lambda({
         id: 'config-merge-lambda-two',
         options: {
-            runtime: 'nodejs10.15',
+            runtime: 'nodejs12.x',
             memorySize: 512,
             exclude: ['exclude.js'],
             include: ['include.js'],

--- a/test/closet/config-merge/serverless.yaml
+++ b/test/closet/config-merge/serverless.yaml
@@ -2,6 +2,7 @@ service: my-service
 
 provider:
   name: aws
+  # Maintained to test mixed lambda versions and ensure lower bound of range is valid
   runtime: nodejs12.x
 
 plugins:

--- a/test/closet/config-merge/serverless.yaml
+++ b/test/closet/config-merge/serverless.yaml
@@ -2,8 +2,7 @@ service: my-service
 
 provider:
   name: aws
-  # Maintained to test mixed lambda versions and ensure lower bound of range is valid
-  runtime: nodejs8.10
+  runtime: nodejs12.x
 
 plugins:
   - lalalambda

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -5,9 +5,8 @@ const StripAnsi = require('strip-ansi');
 const Serverless = require('serverless');
 const ServerlessConfigFile = require('serverless/lib/utils/getServerlessConfigFile');
 const Offline = require('serverless-offline');
-const Somever = require('@hapi/somever');
 
-exports.Hapi = Somever.match(process.version, '>=12') ? require('@hapi/hapi-20') : require('@hapi/hapi');
+exports.Hapi = require('@hapi/hapi');
 
 exports.makeServerless = (servicePath, argv) => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -248,7 +248,7 @@ describe('Lalalambda', () => {
                             lalalambda: {
                                 id: 'y',
                                 options: {
-                                    runtime: 'nodejs10.15'
+                                    runtime: 'nodejs12.x'
                                 }
                             }
                         },
@@ -262,7 +262,7 @@ describe('Lalalambda', () => {
 
                 expect(lambda.id).to.equal('y');
                 expect(lambda.settings).to.equal({
-                    runtime: 'nodejs10.15',
+                    runtime: 'nodejs12.x',
                     events: [
                         {
                             http: {
@@ -815,7 +815,7 @@ describe('Lalalambda', () => {
                         lambdaify: {
                             id: 'x',
                             options: {
-                                runtime: 'nodejs10.15'
+                                runtime: 'nodejs12.x'
                             }
                         }
                     }
@@ -825,7 +825,7 @@ describe('Lalalambda', () => {
 
                 expect(lambda.id).to.equal('x');
                 expect(lambda.settings).to.equal({
-                    runtime: 'nodejs10.15',
+                    runtime: 'nodejs12.x',
                     events: [
                         {
                             http: {
@@ -1198,13 +1198,13 @@ describe('Lalalambda', () => {
             await expect(serverless.run()).to.reject('Lambda "bad-runtime-missing-lambda" must be configured with a nodejs runtime.');
         });
 
-        it('requires the nodejs runtime >=8.10.', async () => {
+        it('requires the nodejs runtime >=12.', async () => {
 
             const serverless = Helpers.makeServerless('bad-runtime-version', []);
 
             await serverless.init();
 
-            await expect(serverless.run()).to.reject('Lambda "bad-runtime-version-lambda" must be configured with a nodejs runtime >=8.10.');
+            await expect(serverless.run()).to.reject('Lambda "bad-runtime-version-lambda" must be configured with a nodejs runtime >=12.');
         });
 
         it('checks per-lambda nodejs runtime.', async () => {
@@ -1235,7 +1235,7 @@ describe('Lalalambda', () => {
             });
 
             expect(config2).to.equal({
-                runtime: 'nodejs10.15',
+                runtime: 'nodejs12.x',
                 include: ['also-include.js', 'include.js'],
                 exclude: ['also-exclude.js', 'exclude.js'],
                 events: [


### PR DESCRIPTION
- dropped support node < 12 & hapi < 19
- update CI to test both hapi@19 and hapi@20
- updated Hapi dependencies and external dependencies
- updated runtime to `node12.x` [as mentioned in AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html)

see #11 

I checked the changelog of the dependencies I upgraded, I didn't saw any potential issues.
I kept `serverless` to v1 just in case